### PR TITLE
Add an Ok-Cancel dialog

### DIFF
--- a/examples/ok-cancel.sh
+++ b/examples/ok-cancel.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+echo "Confirm the operation"
+
+diorite --primary-text="Permanently delete \"/usr\"?" \
+        --secondary-text="This operation is not reversible." \
+        --image-icon-name="dialog-warning" \
+        --ok-text="Delete" \
+        --destructive

--- a/examples/simple-dialog.sh
+++ b/examples/simple-dialog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-echo "Show a simple message to the user after some operations".
+echo "Show a simple message to the user after some operations"
 
 sleep 3
 

--- a/src/AbstractDialog.vala
+++ b/src/AbstractDialog.vala
@@ -22,18 +22,50 @@ public class Diorite.AbstractDialog : Granite.MessageDialog {
     public signal void dialog_close ();
 
     public AbstractDialog (string _primary_text,
-                                 string _secondary_text,
-                                 string _image_icon_name="dialog-information",
-                                 Gtk.ButtonsType _buttons=Gtk.ButtonsType.CLOSE) {
+                           string _secondary_text,
+                           string _image_icon_name="dialog-information",
+                           string ok_text="",
+                           bool suggested=false,
+                           bool destructive=false,
+                           Gtk.ButtonsType _buttons=Gtk.ButtonsType.CLOSE) {
+
+        /* Generally speaking, if there is a request to show
+        text in a suggested action, then it should no longer
+        default to a simple dialog with a "Close" action
+        and should instead show the suggested action and a
+        cancel button. */
+        if (ok_text != "") {
+            _buttons = Gtk.ButtonsType.CANCEL;
+        }
+
         base.with_image_from_icon_name (_primary_text, _secondary_text, _image_icon_name, _buttons);
+
+        /* Need to do this after construct */
+        if (ok_text != "") {
+            var suggested_button = new Gtk.Button.with_label (ok_text);
+
+            // Ignore if both are set to true
+            if (!(suggested && destructive)) {
+                if (suggested) {
+                    suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+                }
+
+                if (destructive) {
+                    suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+                }
+            }
+
+            add_action_widget (suggested_button, Gtk.ResponseType.ACCEPT);
+        }
     }
 
     construct {
         response.connect ((response) => {
-            if (response == Gtk.ResponseType.CLOSE) {
-                dialog_close ();
-                destroy ();
+            if (response == Gtk.ResponseType.ACCEPT) {
+                // Return a value
             }
+            dialog_close ();
+            destroy ();
         });
     }
 }

--- a/src/AbstractDialog.vala
+++ b/src/AbstractDialog.vala
@@ -23,25 +23,30 @@ public class Diorite.AbstractDialog : Granite.MessageDialog {
 
     public AbstractDialog (string _primary_text,
                            string _secondary_text,
-                           string _image_icon_name="dialog-information",
-                           string ok_text="",
+                           string? _image_icon_name="",
+                           string? ok_text="",
                            bool suggested=false,
                            bool destructive=false,
                            Gtk.ButtonsType _buttons=Gtk.ButtonsType.CLOSE) {
+
+        // Apply defaults
+        if (_image_icon_name == null || _image_icon_name == "") {
+            _image_icon_name = "dialog-information";
+        }
 
         /* Generally speaking, if there is a request to show
         text in a suggested action, then it should no longer
         default to a simple dialog with a "Close" action
         and should instead show the suggested action and a
         cancel button. */
-        if (ok_text != "") {
+        if (ok_text != null && ok_text != "") {
             _buttons = Gtk.ButtonsType.CANCEL;
         }
 
         base.with_image_from_icon_name (_primary_text, _secondary_text, _image_icon_name, _buttons);
 
         /* Need to do this after construct */
-        if (ok_text != "") {
+        if (ok_text != null && ok_text != "") {
             var suggested_button = new Gtk.Button.with_label (ok_text);
 
             // Ignore if both are set to true

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,8 +31,8 @@ public class Diorite.Application : Gtk.Application {
 
     public static string primary_text;
     public static string secondary_text;
-    public static string image_icon_name;
-    public static string ok_text;
+    public static string? image_icon_name;
+    public static string? ok_text;
     public static bool suggested = false;
     public static bool destructive = false;
 
@@ -90,22 +90,6 @@ public class Diorite.Application : Gtk.Application {
         if (secondary_text == null) {
             printerr (_("error: No value for argument secondary-text\n"));
             return -1;
-        }
-
-        if (image_icon_name == null) {
-            image_icon_name = "dialog-information";
-        }
-
-        if (ok_text == null) {
-            ok_text = "";
-        }
-
-        if (suggested) {
-            suggested = true;
-        }
-
-        if (destructive) {
-            destructive = true;
         }
 
         return new Application ().run (args);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,15 +20,21 @@
 
 public class Diorite.Application : Gtk.Application {
     public const OptionEntry[] CLI_OPTIONS = {
-        { "primary-text", '\0', OptionFlags.NONE, OptionArg.STRING, out primary_text, "Required: Primary text in dialog", null },
-        { "secondary-text", '\0', OptionFlags.NONE, OptionArg.STRING, out secondary_text, "Required: Secondary text in dialog", null },
-        { "image-icon-name", '\0', OptionFlags.NONE, OptionArg.STRING, out image_icon_name, "Image icon name for dialog.", null },
+        { "primary-text", '\0', OptionFlags.NONE, OptionArg.STRING, out primary_text, "(Required) Primary text in dialog.", null },
+        { "secondary-text", '\0', OptionFlags.NONE, OptionArg.STRING, out secondary_text, "(Required) Secondary text in dialog.", null },
+        { "image-icon-name", '\0', OptionFlags.NONE, OptionArg.STRING, out image_icon_name, "Image icon name for dialog. Default: \"dialog-information\"", null },
+        { "ok-text", '\0', OptionFlags.NONE, OptionArg.STRING, out ok_text, "Adds a suggested button with text specified in flag. Ignore\n\t\t\tthis option if there is no suggested action required. Refer to\n\t\t\thttps://elementary.io/docs/human-interface-guidelines#dialogs\n\t\t\tfor more information. Default: \"\"", null },
+        { "suggested", '\0', OptionFlags.NONE, OptionArg.NONE, out suggested, "Styles the suggested action button with Gtk.STYLE_CLASS_SUGGESTED_ACTION.", null },
+        { "destructive", '\0', OptionFlags.NONE, OptionArg.NONE, out destructive, "Styles the suggested action button with Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION.", null },
         { null }
     };
 
     public static string primary_text;
     public static string secondary_text;
     public static string image_icon_name;
+    public static string ok_text;
+    public static bool suggested = false;
+    public static bool destructive = false;
 
     construct {
         application_id = "com.github.pongloongyeat.diorite";
@@ -46,7 +52,14 @@ public class Diorite.Application : Gtk.Application {
             gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
         });
 
-        var message_dialog = new Diorite.AbstractDialog (primary_text, secondary_text, image_icon_name);
+        var message_dialog = new Diorite.AbstractDialog (
+            primary_text,
+            secondary_text,
+            image_icon_name,
+            ok_text,
+            suggested,
+            destructive
+        );
         message_dialog.show_all ();
 
         // Since there's no window, GTK will exit so it needs to be held and released on exit.
@@ -81,6 +94,18 @@ public class Diorite.Application : Gtk.Application {
 
         if (image_icon_name == null) {
             image_icon_name = "dialog-information";
+        }
+
+        if (ok_text == null) {
+            ok_text = "";
+        }
+
+        if (suggested) {
+            suggested = true;
+        }
+
+        if (destructive) {
+            destructive = true;
         }
 
         return new Application ().run (args);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -59,15 +59,15 @@ public class Diorite.Application : Gtk.Application {
 
     public static int main (string[] args) {
         try {
-			var opt_context = new OptionContext ();
-			opt_context.set_help_enabled (true);
-			opt_context.add_main_entries (CLI_OPTIONS, null);
-			opt_context.parse (ref args);
-		} catch (OptionError e) {
-			printerr (_("error: %s\n"), e.message);
-			printerr (_("Run '%s --help' to see a full list of available command line options.\n"), args[0]);
-			return 1;
-		}
+            var opt_context = new OptionContext ();
+            opt_context.set_help_enabled (true);
+            opt_context.add_main_entries (CLI_OPTIONS, null);
+            opt_context.parse (ref args);
+        } catch (OptionError e) {
+            printerr (_("error: %s\n"), e.message);
+            printerr (_("Run '%s --help' to see a full list of available command line options.\n"), args[0]);
+            return 1;
+        }
 
         if (primary_text == null) {
             printerr (_("error: No value for argument primary-text\n"));


### PR DESCRIPTION
This adds the following flags:
- `ok-text`: Adds a suggested button with text specified in flag
- `suggested`: Styles the suggested action button with Gtk.STYLE_CLASS_SUGGESTED_ACTION.
- `destructive`: Styles the suggested action button with Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION.

Todo:
- [x] Settable Ok name
- [x] Suggested and destructive styles
- [ ] Return action type